### PR TITLE
Prevent recording replays as non admin

### DIFF
--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -39,6 +39,7 @@
     - saveconfig
 
 - Flags: ADMIN
+  Commands:
     - replay_recording_start
     - replay_recording_stop
     - replay_recording_stats


### PR DESCRIPTION
## About the PR
Bad clients can still record them if they really wanted to, but joe genero won't be able to

**Changelog**
:cl:
- remove: Players are no longer allowed to record replays locally
