### PR TITLE
Fix empty consent not adding the placeholder text

### DIFF
--- a/Content.Server/_NS/Consent/Systems/ConsentSystem.cs
+++ b/Content.Server/_NS/Consent/Systems/ConsentSystem.cs
@@ -18,7 +18,7 @@ public sealed class ConsentSystem : SharedConsentSystem
     {
         var text = Loc.GetString("consent-examine-not-set");
 
-        if (_consent.TryGetPlayerConsentSettings(userId, out var consent))
+        if (_consent.TryGetPlayerConsentSettings(userId, out var consent) && consent.Freetext.Length > 0)
         {
             text = consent.Freetext;
         }


### PR DESCRIPTION
## About the PR
Pro

**Changelog**
:cl:
- fix: Not having any freetext consent set will now properly add the placeholder text